### PR TITLE
Remove history_titles and use the RSS file for the same purpose.

### DIFF
--- a/functions/configs.py
+++ b/functions/configs.py
@@ -16,7 +16,6 @@ def af_all_config():
         title_prefix='AF -',
         guid_suffix='_AF',
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='af_all',
         rss_filename='nonlinear-library-aggregated-AF.xml',
         top_post_only=False,
         search_period=None
@@ -34,7 +33,6 @@ def af_daily_config():
         title_prefix='AF - ',
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_DAY,
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='af_daily',
         rss_filename='nonlinear-library-aggregated-AF-daily.xml',
         top_post_only=True
     )
@@ -51,7 +49,6 @@ def af_weekly_config():
         title_prefix='AF - ',
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_WEEK,
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='af_weekly',
         rss_filename='nonlinear-library-aggregated-AF-weekly.xml',
         top_post_only=True
     )
@@ -67,7 +64,6 @@ def ea_all_config():
         title='The Nonlinear Library: EA Forum',
         title_prefix='EA - ',
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='ea_all',
         rss_filename='nonlinear-library-aggregated-EA.xml',
         top_post_only=False
     )
@@ -84,7 +80,6 @@ def ea_daily_config():
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_DAY,
         title_prefix='EA - ',
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='ea_daily',
         rss_filename='nonlinear-library-aggregated-EA-daily.xml',
         top_post_only=True
     )
@@ -101,7 +96,6 @@ def ea_weekly_config():
         title_prefix='EA - ',
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_WEEK,
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='ea_weekly',
         rss_filename='nonlinear-library-aggregated-EA-weekly.xml',
         top_post_only=True
     )
@@ -117,7 +111,6 @@ def lw_all_config():
         title='The Nonlinear Library: LessWrong',
         title_prefix='LW - ',
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='lw_all',
         rss_filename='nonlinear-library-aggregated-LW.xml',
         top_post_only=False
     )
@@ -134,7 +127,6 @@ def lw_daily_config():
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_DAY,
         title_prefix='LW - ',
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='lw_daily',
         rss_filename='nonlinear-library-aggregated-LW-daily.xml',
         top_post_only=True
     )
@@ -151,7 +143,6 @@ def lw_weekly_config():
         title_prefix='LW - ',
         search_period=FeedGeneratorConfig.SearchPeriod.ONE_WEEK,
         gcp_bucket=gcp_bucket_newcode,
-        history_titles_filename='lw_weekly',
         rss_filename='nonlinear-library-aggregated-LW-weekly.xml',
         top_post_only=True
     )

--- a/functions/feed.py
+++ b/functions/feed.py
@@ -13,7 +13,6 @@ class FeedGeneratorConfig:
     image_url: str
     email: str
     author: str
-    history_titles_filename: str
     rss_filename: str
     gcp_bucket: str
     title: str

--- a/functions/podcast_feed_generator.py
+++ b/functions/podcast_feed_generator.py
@@ -158,9 +158,8 @@ def filter_items(feed, feed_config, running_on_gcp) -> List[Element]:
 
     return feed.findall('channel/item')
 
-
-def item_is_in_history(item_title: str, history_titles: list[str]) -> bool:
-    return any(SequenceMatcher(None, item_title, history_title).ratio() > 0.9 for history_title in history_titles)
+def titles_match(title_a: str, title_b: str) -> bool:
+    return SequenceMatcher(None, title_a, title_b).ratio() > 0.9
 
 
 def get_new_items_from_beyondwords_feed(feed_config, running_on_gcp) -> List[Element]:
@@ -195,22 +194,19 @@ def get_new_items_from_beyondwords_feed(feed_config, running_on_gcp) -> List[Ele
 
     print(f'{len(new_items)} items matched the filters')
 
-    storage = create_storage(feed_config, running_on_gcp)
-    history_titles = storage.read_history_titles()
-    new_items_not_in_history = [item for item in
-                                new_items if not item_is_in_history(item.find('title').text, history_titles)]
-
-    print(f'{len(new_items_not_in_history)} of the new items were not in the history.')
-
-    return new_items_not_in_history
+    return new_items
 
 
-def add_items_to_history(feed_config, items: List[Element], running_on_gcp):
-    storage = create_storage(feed_config, running_on_gcp)
-    history_titles = storage.read_history_titles()
-    history_titles += [item.find('title').text for item in items]
-    storage.write_history_titles(history_titles)
-
+def create_new_list_only_containing_items_that_havent_been_added_to_the_rss_file(podcast_feed, new_items):
+    items_which_have_not_been_added = []
+    for new_item in new_items:
+        already_added_to_rss_file = False
+        for item in podcast_feed.findall('./channel/item'):
+            if titles_match(item.find('title').text, new_item.find('title').text):
+                already_added_to_rss_file = True
+        if not already_added_to_rss_file:
+            items_which_have_not_been_added.append(new_item)
+    return items_which_have_not_been_added
 
 def update_podcast_feed(
         feed_config: FeedGeneratorConfig,
@@ -227,10 +223,16 @@ def update_podcast_feed(
 
     new_items = get_new_items_from_beyondwords_feed(feed_config, running_on_gcp)
     if len(new_items) == 0:
+        print('No items match the filter. Returning.')
         return None
 
     storage = create_storage(feed_config, running_on_gcp)
     podcast_feed = storage.read_podcast_feed()
+
+    new_items = create_new_list_only_containing_items_that_havent_been_added_to_the_rss_file(podcast_feed, new_items)
+    if len(new_items) == 0:
+        print('No items were found which are not already contained within the RSS feed. Returning.')
+        return None
 
     # Update values from the provided configuration
     podcast_feed.find('./channel/title').text = feed_config.title
@@ -247,19 +249,15 @@ def update_podcast_feed(
         ElementTree.register_namespace(prefix, uri)
 
     for item in new_items:
+        print('Adding item with title ', item.find('title').text, ' to the RSS feed.')
         podcast_feed.find('./channel').append(item)
 
-    new_items_titles = [item.find('title').text for item in new_items]
-    print(f"Writing to RSS feed {len(new_items)} new entries: {', '.join(new_items_titles)}")
-
     xml_feed = ElementTree.tostring(podcast_feed, encoding='UTF-8', method='xml', xml_declaration=True)
-
-    add_items_to_history(feed_config, new_items, running_on_gcp)
 
     storage = create_storage(feed_config, running_on_gcp)
     storage.write_podcast_feed(xml_feed)
 
-    return storage.rss_filename, new_items_titles
+    return storage.rss_filename, [item.find('title').text for item in new_items]
 
 
 def generate_beyondwords_feed():


### PR DESCRIPTION
I think this is a good change because it gets rid of some complexity. It can also potentially eliminate bugs in the event where the history_titles files accidentally get deleted or messed up - I noticed the code would just write the same item twice to the RSS channel if that happened. Please let me know if you see any issues or drawbacks with this new approach.